### PR TITLE
Update `ccxt` to 1.31.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp==3.6.2
 async-timeout==3.0.1
 attrs==19.3.0
 bech32==1.2.0
-ccxt==1.30.87
+ccxt==1.31.1
 certifi==2020.6.20
 cffi==1.14.0
 chardet==3.0.4


### PR DESCRIPTION
Since `ccxt` package with version `1.30.87` has been removed from their registry, we have to use other version.