### PR TITLE
Fix executor size check on Google function code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: lambda gcf
 
-VERSION=2.0.0
+VERSION=2.0.1
 CURRENT_DIR=$(shell pwd)
 
 lambda:

--- a/google-cloud-functions/google_cloud_function.py
+++ b/google-cloud-functions/google_cloud_function.py
@@ -52,7 +52,8 @@ def execute(request):
     request_json = request.get_json(force=True)
     if "executable" not in request_json:
         return bad_request("Missing executable value")
-    if len(request_json["executable"]) > MAX_EXECUTABLE:
+    executable = base64.b64decode(request_json["executable"])
+    if len(executable) > MAX_EXECUTABLE:
         return bad_request("Executable exceeds max size")
     if "calldata" not in request_json:
         return bad_request("Missing calldata value")
@@ -67,7 +68,7 @@ def execute(request):
 
     path = "/tmp/execute.sh"
     with open(path, "w") as f:
-        f.write(base64.b64decode(request_json["executable"]).decode())
+        f.write(executable.decode())
 
     os.chmod(path, 0o775)
     try:


### PR DESCRIPTION
Data source size limit has been calculated by a raw byte of code, but we used the length of encoded data source on google cloud function code that makes it rejected to run big data source.