### PR TITLE
Update ccxt package version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==21.4.0
 bech32==1.2.0
-ccxt==2.6.22
+ccxt==2.6.1
 certifi==2022.5.18.1
 cffi==1.15.0
 charset-normalizer==2.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==21.4.0
 bech32==1.2.0
-ccxt==1.87.48
+ccxt==2.6.22
 certifi==2022.5.18.1
 cffi==1.15.0
 charset-normalizer==2.0.12


### PR DESCRIPTION
ccxt==1.87.48 cause deployment issue with the below error in google cloud function: ERROR: No matching distribution found for ccxt==1.87.48; Error ID: c84b3231 

I updated requirement.txt with cctx:2.6.22 and deployed it successfully.